### PR TITLE
SystemUI: Allow toggling privacy indicators [1/2]

### DIFF
--- a/core/java/android/permission/PermissionUsageHelper.java
+++ b/core/java/android/permission/PermissionUsageHelper.java
@@ -53,6 +53,7 @@ import android.media.AudioManager;
 import android.os.Process;
 import android.os.UserHandle;
 import android.provider.DeviceConfig;
+import android.provider.Settings;
 import android.telephony.TelephonyManager;
 import android.util.ArrayMap;
 import android.util.ArraySet;
@@ -74,17 +75,6 @@ import java.util.Objects;
  */
 public class PermissionUsageHelper implements AppOpsManager.OnOpActiveChangedListener,
         AppOpsManager.OnOpStartedListener {
-
-    /**
-     * Whether to show the mic and camera icons.
-     */
-    private static final String PROPERTY_CAMERA_MIC_ICONS_ENABLED = "camera_mic_icons_enabled";
-
-    /**
-     * Whether to show the location indicators.
-     */
-    private static final String PROPERTY_LOCATION_INDICATORS_ENABLED =
-            "location_indicators_enabled";
 
     /**
      * Whether to show the Permissions Hub.
@@ -111,14 +101,21 @@ public class PermissionUsageHelper implements AppOpsManager.OnOpActiveChangedLis
                 PROPERTY_PERMISSIONS_HUB_2_ENABLED, false);
     }
 
-    private static boolean shouldShowIndicators() {
-        return DeviceConfig.getBoolean(DeviceConfig.NAMESPACE_PRIVACY,
-                PROPERTY_CAMERA_MIC_ICONS_ENABLED, true) || shouldShowPermissionsHub();
+    private boolean shouldShowIndicators() {
+        return shouldShowCameraIndicator() || shouldShowLocationIndicator() ||
+                shouldShowPermissionsHub();
     }
 
-    private static boolean shouldShowLocationIndicator() {
-        return DeviceConfig.getBoolean(DeviceConfig.NAMESPACE_PRIVACY,
-                PROPERTY_LOCATION_INDICATORS_ENABLED, false);
+     private boolean shouldShowCameraIndicator() {
+        return Settings.Secure.getIntForUser(mContext.getContentResolver(),
+            Settings.Secure.ENABLE_CAMERA_PRIVACY_INDICATOR, 1,
+            UserHandle.USER_CURRENT) == 1;
+    }
+
+    private boolean shouldShowLocationIndicator() {
+        return Settings.Secure.getIntForUser(mContext.getContentResolver(),
+            Settings.Secure.ENABLE_LOCATION_PRIVACY_INDICATOR, 1,
+            UserHandle.USER_CURRENT) == 1;
     }
 
     private static long getRecentThreshold(Long now) {
@@ -299,12 +296,15 @@ public class PermissionUsageHelper implements AppOpsManager.OnOpActiveChangedLis
             return usages;
         }
 
-        List<String> ops = new ArrayList<>(CAMERA_OPS);
+        List<String> ops = new ArrayList<>();
+        if (shouldShowCameraIndicator()) {
+            ops.addAll(CAMERA_OPS);
+            if (!isMicMuted) {
+                ops.addAll(MIC_OPS);
+            }
+        }
         if (shouldShowLocationIndicator()) {
             ops.addAll(LOCATION_OPS);
-        }
-        if (!isMicMuted) {
-            ops.addAll(MIC_OPS);
         }
 
         Map<String, List<OpUsage>> rawUsages = getOpUsages(ops);

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -11528,6 +11528,24 @@ public final class Settings {
         public static final String SYSTEM_BLACK_THEME = "system_black_theme";
 
         /**
+         * Whether to show privacy indicator for location
+         * @hide
+         */
+        public static final String ENABLE_LOCATION_PRIVACY_INDICATOR = "enable_location_privacy_indicator";
+
+        /**
+         * Whether to show privacy indicator for camera
+         * @hide
+         */
+        public static final String ENABLE_CAMERA_PRIVACY_INDICATOR = "enable_camera_privacy_indicator";
+
+        /**
+         * Whether to show privacy indicator for media projection
+         * @hide
+         */
+        public static final String ENABLE_PROJECTION_PRIVACY_INDICATOR = "enable_projection_privacy_indicator";
+
+        /**
          * Keys we no longer back up under the current schema, but want to continue to
          * process when restoring historical backup datasets.
          *

--- a/packages/SystemUI/src/com/android/systemui/privacy/PrivacyConfig.kt
+++ b/packages/SystemUI/src/com/android/systemui/privacy/PrivacyConfig.kt
@@ -16,16 +16,21 @@
 
 package com.android.systemui.privacy
 
+import android.database.ContentObserver
+import android.os.Handler
+import android.os.UserHandle
 import android.provider.DeviceConfig
+import android.provider.Settings
 import com.android.internal.annotations.VisibleForTesting
-import com.android.internal.config.sysui.SystemUiDeviceConfigFlags
+
 import com.android.systemui.Dumpable
 import com.android.systemui.dagger.SysUISingleton
 import com.android.systemui.dagger.qualifiers.Main
 import com.android.systemui.dump.DumpManager
-import com.android.systemui.util.DeviceConfigProxy
+
 import com.android.systemui.util.asIndenting
 import com.android.systemui.util.concurrency.DelayableExecutor
+import com.android.systemui.util.settings.SecureSettings
 import com.android.systemui.util.withIncreasedIndent
 import java.io.PrintWriter
 import java.lang.ref.WeakReference
@@ -34,20 +39,15 @@ import javax.inject.Inject
 @SysUISingleton
 class PrivacyConfig @Inject constructor(
     @Main private val uiExecutor: DelayableExecutor,
-    private val deviceConfigProxy: DeviceConfigProxy,
+    private val secureSettings: SecureSettings,
+    @Main handler: Handler,
     dumpManager: DumpManager
 ) : Dumpable {
 
     @VisibleForTesting
     internal companion object {
         const val TAG = "PrivacyConfig"
-        private const val MIC_CAMERA = SystemUiDeviceConfigFlags.PROPERTY_MIC_CAMERA_ENABLED
-        private const val LOCATION = SystemUiDeviceConfigFlags.PROPERTY_LOCATION_INDICATORS_ENABLED
-        private const val MEDIA_PROJECTION =
-                SystemUiDeviceConfigFlags.PROPERTY_MEDIA_PROJECTION_INDICATORS_ENABLED
-        private const val DEFAULT_MIC_CAMERA = true
-        private const val DEFAULT_LOCATION = false
-        private const val DEFAULT_MEDIA_PROJECTION = true
+
     }
 
     private val callbacks = mutableListOf<WeakReference<Callback>>()
@@ -59,51 +59,46 @@ class PrivacyConfig @Inject constructor(
     var mediaProjectionAvailable = isMediaProjectionEnabled()
         private set
 
-    private val devicePropertiesChangedListener =
-            DeviceConfig.OnPropertiesChangedListener { properties ->
-                if (DeviceConfig.NAMESPACE_PRIVACY == properties.namespace) {
-                    // Running on the ui executor so can iterate on callbacks
-                    if (properties.keyset.contains(MIC_CAMERA)) {
-                        micCameraAvailable = properties.getBoolean(MIC_CAMERA, DEFAULT_MIC_CAMERA)
-                        callbacks.forEach { it.get()?.onFlagMicCameraChanged(micCameraAvailable) }
-                    }
-
-                    if (properties.keyset.contains(LOCATION)) {
-                        locationAvailable = properties.getBoolean(LOCATION, DEFAULT_LOCATION)
-                        callbacks.forEach { it.get()?.onFlagLocationChanged(locationAvailable) }
-                    }
-
-                    if (properties.keyset.contains(MEDIA_PROJECTION)) {
-                        mediaProjectionAvailable =
-                                properties.getBoolean(MEDIA_PROJECTION, DEFAULT_MEDIA_PROJECTION)
-                        callbacks.forEach {
-                            it.get()?.onFlagMediaProjectionChanged(mediaProjectionAvailable)
-                        }
-                    }
-                }
-            }
+    private val settingsObserver = object : ContentObserver(handler) {
+        override fun onChange(selfChange: Boolean) {
+            micCameraAvailable = isMicCameraEnabled()
+            locationAvailable = isLocationEnabled()
+            mediaProjectionAvailable = isMediaProjectionEnabled()
+            callbacks.forEach { it.get()?.onFlagMicCameraChanged(micCameraAvailable) }
+            callbacks.forEach { it.get()?.onFlagLocationChanged(locationAvailable) }
+            callbacks.forEach { it.get()?.onFlagMediaProjectionChanged(mediaProjectionAvailable) }
+        }
+    }
 
     init {
         dumpManager.registerDumpable(TAG, this)
-        deviceConfigProxy.addOnPropertiesChangedListener(
-                DeviceConfig.NAMESPACE_PRIVACY,
-                uiExecutor,
-                devicePropertiesChangedListener)
+        secureSettings.registerContentObserverForUser(
+            Settings.Secure.ENABLE_LOCATION_PRIVACY_INDICATOR,
+            settingsObserver, UserHandle.USER_CURRENT
+        )
+        secureSettings.registerContentObserverForUser(
+            Settings.Secure.ENABLE_CAMERA_PRIVACY_INDICATOR,
+            settingsObserver, UserHandle.USER_CURRENT
+        )
+        secureSettings.registerContentObserverForUser(
+            Settings.Secure.ENABLE_PROJECTION_PRIVACY_INDICATOR,
+            settingsObserver, UserHandle.USER_CURRENT
+        )
     }
 
     private fun isMicCameraEnabled(): Boolean {
-        return deviceConfigProxy.getBoolean(DeviceConfig.NAMESPACE_PRIVACY,
-                MIC_CAMERA, DEFAULT_MIC_CAMERA)
+        return  secureSettings.getIntForUser(
+            Settings.Secure.ENABLE_CAMERA_PRIVACY_INDICATOR, 1, UserHandle.USER_CURRENT) == 1
     }
 
     private fun isLocationEnabled(): Boolean {
-        return deviceConfigProxy.getBoolean(DeviceConfig.NAMESPACE_PRIVACY,
-                LOCATION, DEFAULT_LOCATION)
+        return secureSettings.getIntForUser(
+            Settings.Secure.ENABLE_LOCATION_PRIVACY_INDICATOR, 1, UserHandle.USER_CURRENT) == 1
     }
 
     private fun isMediaProjectionEnabled(): Boolean {
-        return deviceConfigProxy.getBoolean(DeviceConfig.NAMESPACE_PRIVACY,
-                MEDIA_PROJECTION, DEFAULT_MEDIA_PROJECTION)
+        return secureSettings.getIntForUser(
+            Settings.Secure.ENABLE_PROJECTION_PRIVACY_INDICATOR, 1, UserHandle.USER_CURRENT) == 1
     }
 
     fun addCallback(callback: Callback) {
@@ -150,7 +145,7 @@ class PrivacyConfig @Inject constructor(
 
         @JvmDefault
         fun onFlagLocationChanged(flag: Boolean) {}
-
+        
         @JvmDefault
         fun onFlagMediaProjectionChanged(flag: Boolean) {}
     }

--- a/packages/SystemUI/src/com/android/systemui/privacy/PrivacyItemController.kt
+++ b/packages/SystemUI/src/com/android/systemui/privacy/PrivacyItemController.kt
@@ -16,6 +16,8 @@
 
 package com.android.systemui.privacy
 
+import android.os.UserHandle
+import android.provider.Settings
 import com.android.internal.annotations.VisibleForTesting
 import com.android.systemui.Dumpable
 import com.android.systemui.appops.AppOpsController
@@ -26,6 +28,7 @@ import com.android.systemui.dump.DumpManager
 import com.android.systemui.privacy.logging.PrivacyLogger
 import com.android.systemui.util.asIndenting
 import com.android.systemui.util.concurrency.DelayableExecutor
+import com.android.systemui.util.settings.SecureSettings
 import com.android.systemui.util.time.SystemClock
 import com.android.systemui.util.withIncreasedIndent
 import java.io.PrintWriter
@@ -41,6 +44,7 @@ class PrivacyItemController @Inject constructor(
     private val privacyItemMonitors: Set<@JvmSuppressWildcards PrivacyItemMonitor>,
     private val logger: PrivacyLogger,
     private val systemClock: SystemClock,
+    private val secureSettings: SecureSettings,
     dumpManager: DumpManager
 ) : Dumpable {
 
@@ -61,11 +65,16 @@ class PrivacyItemController @Inject constructor(
     private var holdingRunnableCanceler: Runnable? = null
 
     val micCameraAvailable
-        get() = privacyConfig.micCameraAvailable
+        get() = secureSettings.getIntForUser(
+            Settings.Secure.ENABLE_CAMERA_PRIVACY_INDICATOR, 1, UserHandle.USER_CURRENT) == 1
     val locationAvailable
-        get() = privacyConfig.locationAvailable
+        get() = secureSettings.getIntForUser(
+            Settings.Secure.ENABLE_LOCATION_PRIVACY_INDICATOR, 1, UserHandle.USER_CURRENT) == 1
+    val mediaProjectionAvailable
+        get() = secureSettings.getIntForUser(
+            Settings.Secure.ENABLE_PROJECTION_PRIVACY_INDICATOR, 1, UserHandle.USER_CURRENT) == 1
     val allIndicatorsAvailable
-        get() = micCameraAvailable && locationAvailable && privacyConfig.mediaProjectionAvailable
+        get() = micCameraAvailable && locationAvailable && mediaProjectionAvailable
 
     private val notifyChanges = Runnable {
         val list = privacyList

--- a/packages/SystemUI/src/com/android/systemui/qs/HeaderPrivacyIconsController.kt
+++ b/packages/SystemUI/src/com/android/systemui/qs/HeaderPrivacyIconsController.kt
@@ -65,9 +65,7 @@ class HeaderPrivacyIconsController @Inject constructor(
     private var locationIndicatorsEnabled = false
     private var privacyChipLogged = false
     private var safetyCenterEnabled = false
-    private val cameraSlot = privacyChip.resources.getString(R.string.status_bar_camera)
-    private val micSlot = privacyChip.resources.getString(R.string.status_bar_microphone)
-    private val locationSlot = privacyChip.resources.getString(R.string.status_bar_location)
+    
 
     private val safetyCenterReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -127,7 +125,7 @@ class HeaderPrivacyIconsController @Inject constructor(
         }
 
         private fun update() {
-            updatePrivacyIconSlots()
+            
             setChipVisibility(privacyChip.privacyList.isNotEmpty())
         }
     }
@@ -146,12 +144,11 @@ class HeaderPrivacyIconsController @Inject constructor(
                 privacyDialogController.showDialog(privacyChip.context)
             }
         }
-        setChipVisibility(privacyChip.visibility == View.VISIBLE)
+
         micCameraIndicatorsEnabled = privacyItemController.micCameraAvailable
         locationIndicatorsEnabled = privacyItemController.locationAvailable
+        setChipVisibility(privacyChip.visibility == View.VISIBLE)
 
-        // Ignore privacy icons because they show in the space above QQS
-        updatePrivacyIconSlots()
     }
 
     private fun showSafetyCenter() {
@@ -175,6 +172,7 @@ class HeaderPrivacyIconsController @Inject constructor(
     }
 
     fun onParentInvisible() {
+        setChipVisibility(false)
         chipVisibilityListener = null
         privacyChip.setOnClickListener(null)
     }
@@ -191,6 +189,7 @@ class HeaderPrivacyIconsController @Inject constructor(
         listening = false
         privacyItemController.removeCallback(picCallback)
         privacyChipLogged = false
+        setChipVisibility(false)
     }
 
     private fun setChipVisibility(visible: Boolean) {
@@ -208,26 +207,5 @@ class HeaderPrivacyIconsController @Inject constructor(
 
         privacyChip.visibility = if (visible) View.VISIBLE else View.GONE
         chipVisibilityListener?.onChipVisibilityRefreshed(visible)
-    }
-
-    private fun updatePrivacyIconSlots() {
-        if (getChipEnabled()) {
-            if (micCameraIndicatorsEnabled) {
-                iconContainer.addIgnoredSlot(cameraSlot)
-                iconContainer.addIgnoredSlot(micSlot)
-            } else {
-                iconContainer.removeIgnoredSlot(cameraSlot)
-                iconContainer.removeIgnoredSlot(micSlot)
-            }
-            if (locationIndicatorsEnabled) {
-                iconContainer.addIgnoredSlot(locationSlot)
-            } else {
-                iconContainer.removeIgnoredSlot(locationSlot)
-            }
-        } else {
-            iconContainer.removeIgnoredSlot(cameraSlot)
-            iconContainer.removeIgnoredSlot(micSlot)
-            iconContainer.removeIgnoredSlot(locationSlot)
-        }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/DemoStatusIcons.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/DemoStatusIcons.java
@@ -153,12 +153,7 @@ public class DemoStatusIcons extends StatusIconContainer implements DemoMode, Da
                     ? R.drawable.stat_sys_data_bluetooth_connected : 0;
             updateSlot("bluetooth", null, iconId);
         }
-        String location = args.getString("location");
-        if (location != null) {
-            int iconId = location.equals("show") ? PhoneStatusBarPolicy.LOCATION_STATUS_ICON_ID
-                    : 0;
-            updateSlot("location", null, iconId);
-        }
+        
         String alarm = args.getString("alarm");
         if (alarm != null) {
             int iconId = alarm.equals("show") ? R.drawable.stat_sys_alarm

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
@@ -48,10 +48,7 @@ import com.android.systemui.broadcast.BroadcastDispatcher;
 import com.android.systemui.dagger.qualifiers.DisplayId;
 import com.android.systemui.dagger.qualifiers.Main;
 import com.android.systemui.dagger.qualifiers.UiBackground;
-import com.android.systemui.privacy.PrivacyItem;
-import com.android.systemui.privacy.PrivacyItemController;
-import com.android.systemui.privacy.PrivacyType;
-import com.android.systemui.privacy.logging.PrivacyLogger;
+
 import com.android.systemui.qs.tiles.DndTile;
 import com.android.systemui.qs.tiles.RotationLockTile;
 import com.android.systemui.screenrecord.RecordingController;
@@ -66,7 +63,7 @@ import com.android.systemui.statusbar.policy.DeviceProvisionedController;
 import com.android.systemui.statusbar.policy.DeviceProvisionedController.DeviceProvisionedListener;
 import com.android.systemui.statusbar.policy.HotspotController;
 import com.android.systemui.statusbar.policy.KeyguardStateController;
-import com.android.systemui.statusbar.policy.LocationController;
+
 import com.android.systemui.statusbar.policy.NextAlarmController;
 import com.android.systemui.statusbar.policy.RotationLockController;
 import com.android.systemui.statusbar.policy.RotationLockController.RotationLockControllerCallback;
@@ -96,13 +93,12 @@ public class PhoneStatusBarPolicy
                 ZenModeController.Callback,
                 DeviceProvisionedListener,
                 KeyguardStateController.Callback,
-                PrivacyItemController.Callback,
-                LocationController.LocationChangeCallback,
+                
                 RecordingController.RecordingStateChangeCallback {
     private static final String TAG = "PhoneStatusBarPolicy";
     private static final boolean DEBUG = Log.isLoggable(TAG, Log.DEBUG);
 
-    static final int LOCATION_STATUS_ICON_ID = PrivacyType.TYPE_LOCATION.getIconId();
+    
 
     private final String mSlotCast;
     private final String mSlotHotspot;
@@ -116,9 +112,7 @@ public class PhoneStatusBarPolicy
     private final String mSlotRotate;
     private final String mSlotHeadset;
     private final String mSlotDataSaver;
-    private final String mSlotLocation;
-    private final String mSlotMicrophone;
-    private final String mSlotCamera;
+    
     private final String mSlotSensorsOff;
     private final String mSlotScreenRecord;
     private final int mDisplayId;
@@ -144,14 +138,13 @@ public class PhoneStatusBarPolicy
     private final ZenModeController mZenController;
     private final DeviceProvisionedController mProvisionedController;
     private final KeyguardStateController mKeyguardStateController;
-    private final LocationController mLocationController;
-    private final PrivacyItemController mPrivacyItemController;
+   
     private final Executor mMainExecutor;
     private final Executor mUiBgExecutor;
     private final SensorPrivacyController mSensorPrivacyController;
     private final RecordingController mRecordingController;
     private final RingerModeTracker mRingerModeTracker;
-    private final PrivacyLogger mPrivacyLogger;
+    
 
     private boolean mZenVisible;
     private boolean mVibrateVisible;
@@ -174,15 +167,13 @@ public class PhoneStatusBarPolicy
             ZenModeController zenModeController,
             DeviceProvisionedController deviceProvisionedController,
             KeyguardStateController keyguardStateController,
-            LocationController locationController,
+            
             SensorPrivacyController sensorPrivacyController, AlarmManager alarmManager,
             UserManager userManager, UserTracker userTracker,
             DevicePolicyManager devicePolicyManager, RecordingController recordingController,
             @Nullable TelecomManager telecomManager, @DisplayId int displayId,
             @Main SharedPreferences sharedPreferences, DateFormatUtil dateFormatUtil,
-            RingerModeTracker ringerModeTracker,
-            PrivacyItemController privacyItemController,
-            PrivacyLogger privacyLogger) {
+            RingerModeTracker ringerModeTracker) {
         mIconController = iconController;
         mCommandQueue = commandQueue;
         mBroadcastDispatcher = broadcastDispatcher;
@@ -202,15 +193,14 @@ public class PhoneStatusBarPolicy
         mZenController = zenModeController;
         mProvisionedController = deviceProvisionedController;
         mKeyguardStateController = keyguardStateController;
-        mLocationController = locationController;
-        mPrivacyItemController = privacyItemController;
+        
         mSensorPrivacyController = sensorPrivacyController;
         mRecordingController = recordingController;
         mMainExecutor = mainExecutor;
         mUiBgExecutor = uiBgExecutor;
         mTelecomManager = telecomManager;
         mRingerModeTracker = ringerModeTracker;
-        mPrivacyLogger = privacyLogger;
+        
 
         mSlotCast = resources.getString(com.android.internal.R.string.status_bar_cast);
         mSlotHotspot = resources.getString(com.android.internal.R.string.status_bar_hotspot);
@@ -225,9 +215,7 @@ public class PhoneStatusBarPolicy
         mSlotRotate = resources.getString(com.android.internal.R.string.status_bar_rotate);
         mSlotHeadset = resources.getString(com.android.internal.R.string.status_bar_headset);
         mSlotDataSaver = resources.getString(com.android.internal.R.string.status_bar_data_saver);
-        mSlotLocation = resources.getString(com.android.internal.R.string.status_bar_location);
-        mSlotMicrophone = resources.getString(com.android.internal.R.string.status_bar_microphone);
-        mSlotCamera = resources.getString(com.android.internal.R.string.status_bar_camera);
+        
         mSlotSensorsOff = resources.getString(com.android.internal.R.string.status_bar_sensors_off);
         mSlotScreenRecord = resources.getString(
                 com.android.internal.R.string.status_bar_screen_record);
@@ -299,24 +287,6 @@ public class PhoneStatusBarPolicy
         mIconController.setIconVisibility(mSlotDataSaver, false);
 
 
-        // privacy items
-        String microphoneString = mResources.getString(PrivacyType.TYPE_MICROPHONE.getNameId());
-        String microphoneDesc = mResources.getString(
-                R.string.ongoing_privacy_chip_content_multiple_apps, microphoneString);
-        mIconController.setIcon(mSlotMicrophone, PrivacyType.TYPE_MICROPHONE.getIconId(),
-                microphoneDesc);
-        mIconController.setIconVisibility(mSlotMicrophone, false);
-
-        String cameraString = mResources.getString(PrivacyType.TYPE_CAMERA.getNameId());
-        String cameraDesc = mResources.getString(
-                R.string.ongoing_privacy_chip_content_multiple_apps, cameraString);
-        mIconController.setIcon(mSlotCamera, PrivacyType.TYPE_CAMERA.getIconId(),
-                cameraDesc);
-        mIconController.setIconVisibility(mSlotCamera, false);
-
-        mIconController.setIcon(mSlotLocation, LOCATION_STATUS_ICON_ID,
-                mResources.getString(R.string.accessibility_location_active));
-        mIconController.setIconVisibility(mSlotLocation, false);
 
         // sensors off
         mIconController.setIcon(mSlotSensorsOff, R.drawable.stat_sys_sensors_off,
@@ -338,9 +308,9 @@ public class PhoneStatusBarPolicy
         mNextAlarmController.addCallback(mNextAlarmCallback);
         mDataSaver.addCallback(this);
         mKeyguardStateController.addCallback(this);
-        mPrivacyItemController.addCallback(this);
+        
         mSensorPrivacyController.addCallback(mSensorPrivacyListener);
-        mLocationController.addCallback(this);
+        
         mRecordingController.addCallback(this);
 
         mCommandQueue.addCallback(this);
@@ -662,62 +632,6 @@ public class PhoneStatusBarPolicy
         mIconController.setIconVisibility(mSlotDataSaver, isDataSaving);
     }
 
-    @Override  // PrivacyItemController.Callback
-    public void onPrivacyItemsChanged(List<PrivacyItem> privacyItems) {
-        updatePrivacyItems(privacyItems);
-    }
-
-    private void updatePrivacyItems(List<PrivacyItem> items) {
-        boolean showCamera = false;
-        boolean showMicrophone = false;
-        boolean showLocation = false;
-        for (PrivacyItem item : items) {
-            if (item == null /* b/124234367 */) {
-                Log.e(TAG, "updatePrivacyItems - null item found");
-                StringWriter out = new StringWriter();
-                mPrivacyItemController.dump(new PrintWriter(out), null);
-                // Throw so we can look into this
-                throw new NullPointerException(out.toString());
-            }
-            switch (item.getPrivacyType()) {
-                case TYPE_CAMERA:
-                    showCamera = true;
-                    break;
-                case TYPE_LOCATION:
-                    showLocation = true;
-                    break;
-                case TYPE_MICROPHONE:
-                    showMicrophone = true;
-                    break;
-            }
-        }
-
-        // Disabling for now, but keeping the log
-        /*
-        mIconController.setIconVisibility(mSlotCamera, showCamera);
-        mIconController.setIconVisibility(mSlotMicrophone, showMicrophone);
-        if (mPrivacyItemController.getLocationAvailable()) {
-            mIconController.setIconVisibility(mSlotLocation, showLocation);
-        }
-         */
-        mPrivacyLogger.logStatusBarIconsVisible(showCamera, showMicrophone,  showLocation);
-    }
-
-    @Override
-    public void onLocationActiveChanged(boolean active) {
-        if (!mPrivacyItemController.getLocationAvailable()) {
-            updateLocationFromController();
-        }
-    }
-
-    // Updates the status view based on the current state of location requests.
-    private void updateLocationFromController() {
-        if (mLocationController.isLocationActive()) {
-            mIconController.setIconVisibility(mSlotLocation, true);
-        } else {
-            mIconController.setIconVisibility(mSlotLocation, false);
-        }
-    }
 
     private BroadcastReceiver mIntentReceiver = new BroadcastReceiver() {
         @Override


### PR DESCRIPTION
SystemUI: Kill old privacy indicator icons completely
* It's messy to keep both versions.

Completed fixing code