### PR TITLE
 SystemUI: add left and right virtual buttons while typing

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -6204,6 +6204,13 @@ public final class Settings {
         public static final String CLICK_PARTIAL_SCREENSHOT = "click_partial_screenshot";
 
         /**
+         * boolean value. toggles using arrow key locations on nav bar
+         * as left and right dpad keys
+         * @hide
+         */
+        public static final String NAVIGATION_BAR_MENU_ARROW_KEYS = "navigation_bar_menu_arrow_keys";
+
+        /**
          * @hide
          */
         public static final String USE_OLD_MOBILETYPE = "use_old_mobiletype";

--- a/packages/SystemUI/res/drawable/ic_chevron_end.xml
+++ b/packages/SystemUI/res/drawable/ic_chevron_end.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright (C) 2015 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="20dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24"
+        android:tint="?attr/colorControlNormal"
+        android:autoMirrored="true">
+    <path
+        android:fillColor="?attr/singleToneColor"
+        android:pathData="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6,-6z"/>
+</vector>

--- a/packages/SystemUI/res/drawable/ic_chevron_start.xml
+++ b/packages/SystemUI/res/drawable/ic_chevron_start.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright (C) 2015 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="20dp"
+        android:height="20dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24"
+        android:tint="?attr/colorControlNormal"
+        android:autoMirrored="true">
+    <path
+        android:fillColor="?attr/singleToneColor"
+        android:pathData="M15.41 7.41L14 6l-6 6 6 6 1.41,-1.41L10.83 12z"/>
+</vector>

--- a/packages/SystemUI/res/layout/nav_buttons_dpad_group.xml
+++ b/packages/SystemUI/res/layout/nav_buttons_dpad_group.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2016 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:systemui="http://schemas.android.com/apk/res-auto">
+
+    <com.android.systemui.navigationbar.buttons.KeyButtonView
+        android:id="@+id/dpad_left"
+        android:layout_width="@dimen/navigation_side_padding"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        systemui:keyCode="21"
+        android:scaleType="center"
+        android:contentDescription="@string/accessibility_dpad_left" />
+
+    <com.android.systemui.navigationbar.buttons.KeyButtonView
+        android:id="@+id/dpad_right"
+        android:layout_width="@dimen/navigation_side_padding"
+        android:layout_height="match_parent"
+        android:layout_gravity="end"
+        systemui:keyCode="22"
+        android:scaleType="center"
+        android:contentDescription="@string/accessibility_dpad_right" />
+
+</merge>

--- a/packages/SystemUI/res/layout/nav_buttons_dpad_group_vertical.xml
+++ b/packages/SystemUI/res/layout/nav_buttons_dpad_group_vertical.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2016 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:systemui="http://schemas.android.com/apk/res-auto">
+
+    <com.android.systemui.navigationbar.buttons.KeyButtonView
+        android:id="@+id/dpad_left"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/navigation_side_padding"
+        android:layout_gravity="top"
+        systemui:keyCode="21"
+        android:scaleType="center"
+        android:contentDescription="@string/accessibility_dpad_left" />
+
+    <com.android.systemui.navigationbar.buttons.KeyButtonView
+        android:id="@+id/dpad_right"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/navigation_side_padding"
+        android:layout_gravity="bottom"
+        systemui:keyCode="22"
+        android:scaleType="center"
+        android:contentDescription="@string/accessibility_dpad_right" />
+
+</merge>

--- a/packages/SystemUI/res/layout/navigation_layout.xml
+++ b/packages/SystemUI/res/layout/navigation_layout.xml
@@ -53,6 +53,12 @@
             android:clipToPadding="false"
             android:clipChildren="false" />
 
+        <FrameLayout
+            android:id="@+id/dpad_group"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipChildren="false" />
+
     </com.android.systemui.navigationbar.buttons.NearestTouchFrame>
 
 </FrameLayout>

--- a/packages/SystemUI/res/layout/navigation_layout_vertical.xml
+++ b/packages/SystemUI/res/layout/navigation_layout_vertical.xml
@@ -50,6 +50,12 @@
             android:clipToPadding="false"
             android:clipChildren="false" />
 
+        <FrameLayout
+            android:id="@+id/dpad_group"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipChildren="false" />
+
     </com.android.systemui.navigationbar.buttons.NearestTouchFrame>
 
 </FrameLayout>

--- a/packages/SystemUI/res/values-de/afterlife_strings.xml
+++ b/packages/SystemUI/res/values-de/afterlife_strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+     Copyright (C) 2023 DerpFest
+     Copyright (C) 2023 AfterLife Project
+     SPDX-License-Identifier: Apache-2.0
+-->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- Navigation bar dpad -->
+    <string name="accessibility_dpad_left">Cursor links</string>
+    <string name="accessibility_dpad_right">Cursor rechts</string>
+
+</resources>

--- a/packages/SystemUI/res/values/afterlife_strings.xml
+++ b/packages/SystemUI/res/values/afterlife_strings.xml
@@ -155,4 +155,8 @@
 
     <!-- Google lens screenshot notification -->
     <string name="lens">Lens</string>
+
+    <!-- Navigation bar dpad -->
+    <string name="accessibility_dpad_left">Cursor left</string>
+    <string name="accessibility_dpad_right">Cursor right</string>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBar.java
+++ b/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBar.java
@@ -1765,6 +1765,10 @@ public class NavigationBar extends ViewController<NavigationBarView> implements 
         updateButtonLocation(
                 region, touchRegionCache, mView.getAccessibilityButton(), inScreenSpace,
                 useNearestRegion);
+        updateButtonLocation(region, touchRegionCache, mView.getCursorLeftButton(), inScreenSpace,
+                useNearestRegion);
+        updateButtonLocation(region, touchRegionCache, mView.getCursorRightButton(), inScreenSpace,
+                useNearestRegion);
         if (includeFloatingButtons && mView.getFloatingRotationButton().isVisible()) {
             // Note: this button is floating so the nearest region doesn't apply
             updateButtonLocation(

--- a/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBarInflaterView.java
+++ b/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBarInflaterView.java
@@ -213,8 +213,10 @@ public class NavigationBarInflaterView extends FrameLayout
     private void initiallyFill(ButtonDispatcher buttonDispatcher) {
         addAll(buttonDispatcher, mHorizontal.findViewById(R.id.ends_group));
         addAll(buttonDispatcher, mHorizontal.findViewById(R.id.center_group));
+        addAll(buttonDispatcher, mHorizontal.findViewById(R.id.dpad_group));
         addAll(buttonDispatcher, mVertical.findViewById(R.id.ends_group));
         addAll(buttonDispatcher, mVertical.findViewById(R.id.center_group));
+        addAll(buttonDispatcher, mVertical.findViewById(R.id.dpad_group));
     }
 
     private void addAll(ButtonDispatcher buttonDispatcher, ViewGroup parent) {
@@ -264,6 +266,9 @@ public class NavigationBarInflaterView extends FrameLayout
         inflateButtons(end, mVertical.findViewById(R.id.ends_group),
                 true /* landscape */, false /* start */);
 
+        inflateCursorButtons(mHorizontal.findViewById(R.id.dpad_group), false /* landscape */);
+        inflateCursorButtons(mVertical.findViewById(R.id.dpad_group), true /* landscape */);
+
         updateButtonDispatchersCurrentView();
     }
 
@@ -276,6 +281,14 @@ public class NavigationBarInflaterView extends FrameLayout
         for (int i = 0; i < buttons.length; i++) {
             inflateButton(buttons[i], parent, landscape, start);
         }
+    }
+
+    private void inflateCursorButtons(ViewGroup parent, boolean landscape) {
+        LayoutInflater inflater = landscape ? mLandscapeInflater : mLayoutInflater;
+        final int layoutResId = landscape ?
+                R.layout.nav_buttons_dpad_group_vertical : R.layout.nav_buttons_dpad_group;
+        View v = inflater.inflate(layoutResId, parent);
+        addToDispatchers(parent);
     }
 
     private ViewGroup.LayoutParams copy(ViewGroup.LayoutParams layoutParams) {

--- a/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBarView.java
@@ -60,6 +60,7 @@ import androidx.annotation.Nullable;
 
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.settingslib.Utils;
+import com.android.systemui.Dependency;
 import com.android.systemui.Gefingerpoken;
 import com.android.systemui.R;
 import com.android.systemui.animation.Interpolators;
@@ -82,8 +83,11 @@ import com.android.systemui.shared.system.QuickStepContract;
 import com.android.systemui.statusbar.phone.AutoHideController;
 import com.android.systemui.statusbar.phone.CentralSurfaces;
 import com.android.systemui.statusbar.phone.LightBarTransitionsController;
+import com.android.systemui.tuner.TunerService;
 import com.android.wm.shell.back.BackAnimation;
 import com.android.wm.shell.pip.Pip;
+
+import android.provider.Settings;
 
 import java.io.PrintWriter;
 import java.util.Map;
@@ -92,9 +96,12 @@ import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 /** */
-public class NavigationBarView extends FrameLayout {
+ public class NavigationBarView extends FrameLayout implements TunerService.Tunable {
     final static boolean DEBUG = false;
     final static String TAG = "NavBarView";
+
+    private static final String NAVIGATION_BAR_MENU_ARROW_KEYS =
+            "customsystem:" + Settings.System.NAVIGATION_BAR_MENU_ARROW_KEYS;
 
     final static boolean ALTERNATE_CAR_MODE_UI = false;
 
@@ -119,6 +126,8 @@ public class NavigationBarView extends FrameLayout {
     private KeyButtonDrawable mHomeDefaultIcon;
     private KeyButtonDrawable mRecentIcon;
     private KeyButtonDrawable mDockedIcon;
+    private KeyButtonDrawable mCursorRightIcon;
+    private KeyButtonDrawable mCursorLeftIcon;
     private Context mLightContext;
     private int mLightIconColor;
     private int mDarkIconColor;
@@ -176,6 +185,9 @@ public class NavigationBarView extends FrameLayout {
     private boolean mOverviewProxyEnabled;
     private boolean mShowSwipeUpUi;
     private UpdateActiveTouchRegionsCallback mUpdateActiveTouchRegionsCallback;
+
+    private boolean mShowCursorKeys;
+    private boolean mImeVisible;
 
     private class NavTransitionListener implements TransitionListener {
         private boolean mBackTransitioning;
@@ -288,6 +300,10 @@ public class NavigationBarView extends FrameLayout {
         final ContextualButton accessibilityButton =
                 new ContextualButton(R.id.accessibility_button, mLightContext,
                         R.drawable.ic_sysbar_accessibility_button);
+        final ContextualButton cursorLeftButton = new ContextualButton(R.id.dpad_left,
+                mLightContext, R.drawable.ic_chevron_start);
+        final ContextualButton cursorRightButton = new ContextualButton(R.id.dpad_right,
+                mLightContext, R.drawable.ic_chevron_end);
         mContextualButtonGroup.addButton(imeSwitcherButton);
         mContextualButtonGroup.addButton(accessibilityButton);
         mRotationContextButton = new RotationContextButton(R.id.rotate_suggestion,
@@ -323,6 +339,8 @@ public class NavigationBarView extends FrameLayout {
         mButtonDispatchers.put(R.id.ime_switcher, imeSwitcherButton);
         mButtonDispatchers.put(R.id.accessibility_button, accessibilityButton);
         mButtonDispatchers.put(R.id.menu_container, mContextualButtonGroup);
+        mButtonDispatchers.put(R.id.dpad_left, cursorLeftButton);
+        mButtonDispatchers.put(R.id.dpad_right, cursorRightButton);
         mDeadZone = new DeadZone(this);
     }
 
@@ -435,6 +453,14 @@ public class NavigationBarView extends FrameLayout {
         return mButtonDispatchers.get(R.id.home_handle);
     }
 
+    public ButtonDispatcher getCursorLeftButton() {
+        return mButtonDispatchers.get(R.id.dpad_left);
+    }
+
+    public ButtonDispatcher getCursorRightButton() {
+        return mButtonDispatchers.get(R.id.dpad_right);
+    }
+
     public SparseArray<ButtonDispatcher> getButtonDispatchers() {
         return mButtonDispatchers;
     }
@@ -466,6 +492,8 @@ public class NavigationBarView extends FrameLayout {
         }
         if (densityChange || dirChange) {
             mRecentIcon = getDrawable(R.drawable.ic_sysbar_recent);
+            mCursorLeftIcon = getDrawable(R.drawable.ic_chevron_start);
+            mCursorRightIcon = getDrawable(R.drawable.ic_chevron_end);
             mContextualButtonGroup.updateIcons(mLightIconColor, mDarkIconColor);
         }
         if (orientationChange || densityChange || dirChange) {
@@ -582,6 +610,7 @@ public class NavigationBarView extends FrameLayout {
         if (!visible) {
             mTransitionListener.onBackAltCleared();
         }
+        mImeVisible = visible;
         mRotationButtonController.getRotationButton().setCanShowRotationButton(!visible);
     }
 
@@ -610,18 +639,25 @@ public class NavigationBarView extends FrameLayout {
         KeyButtonDrawable backIcon = mBackIcon;
         orientBackButton(backIcon);
         KeyButtonDrawable homeIcon = mHomeDefaultIcon;
+        KeyButtonDrawable cursorLeftIcon = mCursorLeftIcon;
+        KeyButtonDrawable cursorRightIcon = mCursorRightIcon;
         if (!mUseCarModeUi) {
             orientHomeButton(homeIcon);
         }
         getHomeButton().setImageDrawable(homeIcon);
         getBackButton().setImageDrawable(backIcon);
+        getCursorLeftButton().setImageDrawable(cursorLeftIcon);
+        getCursorRightButton().setImageDrawable(cursorRightIcon);
 
         updateRecentsIcon();
+
+        boolean disableCursorKeys = !mShowCursorKeys || !useAltBack ||
+                (QuickStepContract.isGesturalMode(mNavBarMode) && mImeVisible);
 
         // Update IME button visibility, a11y and rotate button always overrides the appearance
         boolean disableImeSwitcher =
                 (mNavigationIconHints & StatusBarManager.NAVIGATION_HINT_IME_SWITCHER_SHOWN) == 0
-                || isImeRenderingNavButtons();
+                || isImeRenderingNavButtons() || !disableCursorKeys;
         mContextualButtonGroup.setButtonVisibility(R.id.ime_switcher, !disableImeSwitcher);
 
         mBarTransitions.reapplyDarkIntensity();
@@ -667,6 +703,8 @@ public class NavigationBarView extends FrameLayout {
         getHomeButton().setVisibility(disableHome       ? View.INVISIBLE : View.VISIBLE);
         getRecentsButton().setVisibility(disableRecent  ? View.INVISIBLE : View.VISIBLE);
         getHomeHandle().setVisibility(disableHomeHandle ? View.INVISIBLE : View.VISIBLE);
+        getCursorLeftButton().setVisibility(disableCursorKeys  ? View.INVISIBLE : View.VISIBLE);
+        getCursorRightButton().setVisibility(disableCursorKeys ? View.INVISIBLE : View.VISIBLE);
         notifyActiveTouchRegions();
     }
 
@@ -1095,6 +1133,8 @@ public class NavigationBarView extends FrameLayout {
         super.onAttachedToWindow();
         requestApplyInsets();
         reorient();
+        final TunerService tunerService = Dependency.get(TunerService.class);
+        tunerService.addTunable(this, NAVIGATION_BAR_MENU_ARROW_KEYS);
         if (mRotationButtonController != null) {
             mRotationButtonController.registerListeners(false /* registerRotationWatcher */);
         }
@@ -1111,6 +1151,14 @@ public class NavigationBarView extends FrameLayout {
         if (mRotationButtonController != null) {
             mFloatingRotationButton.hide();
             mRotationButtonController.unregisterListeners();
+        }
+    }
+
+    @Override
+    public void onTuningChanged(String key, String newValue) {
+        if (NAVIGATION_BAR_MENU_ARROW_KEYS.equals(key)) {
+            mShowCursorKeys = TunerService.parseIntegerSwitch(newValue, false);
+            setNavigationIconHints(mNavigationIconHints);
         }
     }
 
@@ -1151,6 +1199,8 @@ public class NavigationBarView extends FrameLayout {
         dumpButton(pw, "rota", getRotateSuggestionButton());
         dumpButton(pw, "a11y", getAccessibilityButton());
         dumpButton(pw, "ime", getImeSwitchButton());
+        dumpButton(pw, "curl", getCursorLeftButton());
+        dumpButton(pw, "curr", getCursorRightButton());
 
         if (mNavigationInflaterView != null) {
             mNavigationInflaterView.dump(pw);

--- a/packages/SystemUI/src/com/android/systemui/navigationbar/buttons/KeyButtonView.java
+++ b/packages/SystemUI/src/com/android/systemui/navigationbar/buttons/KeyButtonView.java
@@ -64,6 +64,9 @@ import com.android.systemui.shared.system.QuickStepContract;
 public class KeyButtonView extends ImageView implements ButtonInterface {
     private static final String TAG = KeyButtonView.class.getSimpleName();
 
+    private static final int CURSOR_REPEAT_FLAGS = KeyEvent.FLAG_SOFT_KEYBOARD
+            | KeyEvent.FLAG_KEEP_TOUCH_MODE;
+
     private final boolean mPlaySounds;
     private final UiEventLogger mUiEventLogger;
     private int mContentDescriptionRes;
@@ -125,7 +128,13 @@ public class KeyButtonView extends ImageView implements ButtonInterface {
         public void run() {
             if (isPressed()) {
                 // Log.d("KeyButtonView", "longpressed: " + this);
-                if (isLongClickable()) {
+                if (mCode == KeyEvent.KEYCODE_DPAD_LEFT || mCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                    sendEvent(KeyEvent.ACTION_UP, CURSOR_REPEAT_FLAGS,
+                            System.currentTimeMillis(), false);
+                    sendEvent(KeyEvent.ACTION_DOWN, CURSOR_REPEAT_FLAGS,
+                            System.currentTimeMillis(), false);
+                    postDelayed(mCheckLongPress, ViewConfiguration.getKeyRepeatDelay());
+                } else if (isLongClickable()) {
                     // Just an old-fashioned ImageView
                     performLongClick();
                     mLongClicked = true;
@@ -275,7 +284,10 @@ public class KeyButtonView extends ImageView implements ButtonInterface {
 
                 mTouchDownX = (int) ev.getX();
                 mTouchDownY = (int) ev.getY();
-                if (mCode != KEYCODE_UNKNOWN) {
+                if (mCode == KeyEvent.KEYCODE_DPAD_LEFT || mCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                    sendEvent(KeyEvent.ACTION_DOWN, KeyEvent.FLAG_VIRTUAL_HARD_KEY
+                            | KeyEvent.FLAG_KEEP_TOUCH_MODE, mDownTime, false);
+                } else if (mCode != KEYCODE_UNKNOWN) {
                     sendEvent(KeyEvent.ACTION_DOWN, 0, mDownTime);
                 } else {
                     // Provide the same haptic feedback that the system offers for virtual keys.
@@ -404,6 +416,10 @@ public class KeyButtonView extends ImageView implements ButtonInterface {
     }
 
     private void sendEvent(int action, int flags, long when) {
+        sendEvent(action, flags, when, true);
+    }
+
+    private void sendEvent(int action, int flags, long when, boolean applyDefaultFlags) {
         mMetricsLogger.write(new LogMaker(MetricsEvent.ACTION_NAV_BUTTON_EVENT)
                 .setType(MetricsEvent.TYPE_ACTION)
                 .setSubtype(mCode)
@@ -414,9 +430,12 @@ public class KeyButtonView extends ImageView implements ButtonInterface {
             Log.i(TAG, "Back button event: " + KeyEvent.actionToString(action));
         }
         final int repeatCount = (flags & KeyEvent.FLAG_LONG_PRESS) != 0 ? 1 : 0;
+        if (applyDefaultFlags) {
+            flags |= KeyEvent.FLAG_FROM_SYSTEM | KeyEvent.FLAG_VIRTUAL_HARD_KEY;
+        }
         final KeyEvent ev = new KeyEvent(mDownTime, when, action, mCode, repeatCount,
                 0, KeyCharacterMap.VIRTUAL_KEYBOARD, 0,
-                flags | KeyEvent.FLAG_FROM_SYSTEM | KeyEvent.FLAG_VIRTUAL_HARD_KEY,
+                flags,
                 InputDevice.SOURCE_NAVIGATION_BAR);
 
         int displayId = INVALID_DISPLAY;


### PR DESCRIPTION
[cyanogen] refactor for cm-14.0
[LuK1337] update for 8.1
[sam3000] Updates for ten

* Removed keyRepeat attribute from layouts because it defaults to true and AOSP removed it anyway in commit 160ad6b

* Removed layout-sw600dp layout changes because AOSP refactored to use layout instead as seen in commit aa94d95

* Renamed rot90 layout suffix to vertical as per AOSP changes

[maniac103] More refactorings for ten

* Follow new system of inflating all views dynamically

Squashes the following commits:

Author: Danny Baumann <dannybaumann@web.de>
Date:   Wed Aug 6 09:16:35 2014 +0200

    Fix side button visibility tracking.

    Previously one could e.g. get legacy menu button being visible in
    certain scenarios, like this one:
    - Open legacy app, e.g. CatLog
    - Invoke IME
    - Lock screen
    - Unlock screen
    - Result: Menu button visible in keyguard

    Change-Id: Ia796f73ec995ea1cc34d38f8aefdbccda7be7565

Author: Roman Birg <roman@cyngn.com>
Date:   Wed Jul 2 09:31:23 2014 -0700

    SystemUI: fix up navigation cursor keyevent flags

    Volume cursor controls use slightly different flags to keep the cursor
    within the field. Match them in the SystemUI for consistent (and better)
    behavior.

    Change-Id: I56d597f111ec611b0ca24a10f30575401fa76d18
    Signed-off-by: Roman Birg <roman@cyngn.com>

Author: Roman Birg <roman@cyngn.com>
Date:   Thu Jul 3 12:04:40 2014 -0700

    SystemUI: fix up initial cursor down flags on nav bar

    We were using the regular flags for the initial ACTION_DOWN event so the
    FLAG_KEEP_TOUCH_MODE was not being passed and allowed the cursor to jump
    out of bounds slightly.

    Change-Id: I5b4d2a5e5e0ce562985fcc3b7b6fac8b4abc49da
    Signed-off-by: Roman Birg <roman@cyngn.com>

Author: LuK1337 <priv.luk@gmail.com>
Date:   Thu Apr 19 01:14:21 2018 +0200

    SystemUI: Fix navigation bar arrows visibility handling

    * Fixes issue where input events would be sent
      while dpad_group view was set to be invisible.

    Change-Id: Ie802e9c8157505a2ad706332f0b2fe715caf428c

Author: Bruno Martins <bgcngm@gmail.com>
Date:   Sun Apr 19 23:17:12 2020 +0100

    NavigationBarView: Fix cursor keys visibility with gestural mode enabled

    When gestural mode is enabled and the IME is being shown
    the cursor keys must be hidden, otherwise there's an overlap.

    Fixes: https://gitlab.com/LineageOS/issues/android/-/issues/1730
    Change-Id: I2f34810d7b137573360a140bbf267028363e6a28

Change-Id: Iea446443d33ff305765e47c86523b619676116ac