### PR TITLE
Add kill button to notification guts [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -6187,21 +6187,21 @@ public final class Settings {
          *
          * @hide
          */
-        public static final String ANIM_TILE_STYLE = "anim_tile_style";
+        public static final String QS_TILE_ANIMATION_STYLE = "qs_tile_animation_style";
 
         /**
          * Change quick settings tiles animation duration
          *
          * @hide
          */
-        public static final String ANIM_TILE_DURATION = "anim_tile_duration";
+        public static final String QS_TILE_ANIMATION_DURATION = "qs_tile_animation_duration";
 
         /**
          * Change quick settings tiles interpolator
          *
          * @hide
          */
-        public static final String ANIM_TILE_INTERPOLATOR = "anim_tile_interpolator";
+        public static final String QS_TILE_ANIMATION_INTERPOLATOR = "qs_tile_animation_interpolator";
 
         /**
          * Whether the torch launch gesture when the screen is off should be enabled.

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -6304,6 +6304,13 @@ public final class Settings {
         public static final String STATUS_BAR_LOGO_STYLE = "status_bar_logo_style";
 
         /**
+         * Whether to show the kill app button in notification guts
+         * @hide
+         */
+        public static final String NOTIFICATION_GUTS_KILL_APP_BUTTON =
+                "notification_guts_kill_app_button";
+
+        /**
          * Whether to enable or disable vibration on succesful fingerprint auth
          * @hide
          */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -6311,6 +6311,18 @@ public final class Settings {
                 "notification_guts_kill_app_button";
 
         /**
+         * Whether to enable charge battery warning
+         * @hide
+         */
+        public static final String BATTERY_LEVEL_CHARGE_ALARM_ENABLED = "battery_level_charge_alarm_enabled";
+
+        /**
+         * Change level for charge battery warning
+         * @hide
+         */
+        public static final String SEEK_BAR_BATTERY_CHARGE_LEVEL_SOUND = "battery_level_charge_seek_bar";
+
+        /**
          * Whether to enable or disable vibration on succesful fingerprint auth
          * @hide
          */
@@ -8580,6 +8592,12 @@ public final class Settings {
          */
         @Readable
         public static final String CHARGING_VIBRATION_ENABLED = "charging_vibration_enabled";
+
+        /**
+         * Ringtone for battery charge level warning.
+         * @hide
+         */
+        public static final String BATTERY_LEVEL_CHARGE_SOUND_ALARM = "battery_level_charge_ringtone";
 
         /**
          * If 0, turning on dnd manually will last indefinitely.

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -6304,6 +6304,11 @@ public final class Settings {
         public static final String STATUS_BAR_LOGO_STYLE = "status_bar_logo_style";
 
         /**
+         * @hide
+         */
+        public static final String QS_TRANSPARENCY = "qs_transparency";
+
+        /**
          * Whether to show the kill app button in notification guts
          * @hide
          */

--- a/data/etc/com.android.systemui.xml
+++ b/data/etc/com.android.systemui.xml
@@ -31,6 +31,7 @@
         <permission name="android.permission.CONTROL_REMOTE_APP_TRANSITION_ANIMATIONS"/>
         <permission name="android.permission.CONTROL_VPN"/>
         <permission name="android.permission.DUMP"/>
+        <permission name="android.permission.FORCE_STOP_PACKAGES" />
         <permission name="android.permission.GET_APP_OPS_STATS"/>
         <permission name="android.permission.INTERACT_ACROSS_USERS"/>
         <permission name="android.permission.INTERACT_ACROSS_USERS_FULL"/>

--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -344,6 +344,9 @@
     <!-- To broadcast status of the GameSpaceManager -->
     <uses-permission android:name="android.permission.MANAGE_GAME_MODE" />
 
+    <!-- Kill button in notification guts -->
+    <uses-permission android:name="android.permission.FORCE_STOP_PACKAGES" />
+
     <protected-broadcast android:name="com.android.settingslib.action.REGISTER_SLICE_RECEIVER" />
     <protected-broadcast android:name="com.android.settingslib.action.UNREGISTER_SLICE_RECEIVER" />
 

--- a/packages/SystemUI/res/drawable/ic_force_stop.xml
+++ b/packages/SystemUI/res/drawable/ic_force_stop.xml
@@ -1,0 +1,31 @@
+<!--
+  Copyright (C) 2018 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12,5.99L19.53,19H4.47L12,5.99M12,2L1,21h22L12,2L12,2z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M13,16l-2,0l0,2l2,0l0,-2z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M13,10l-2,0l0,4l2,0l0,-4z"/>
+</vector>

--- a/packages/SystemUI/res/layout/notification_info.xml
+++ b/packages/SystemUI/res/layout/notification_info.xml
@@ -92,6 +92,18 @@
         <!-- end aligned fields -->
         <!-- Optional link to app. Only appears if the channel is not disabled and the app
 asked for it -->
+
+        <ImageButton
+            android:id="@+id/force_stop"
+            android:layout_width="@dimen/notification_importance_toggle_size"
+            android:layout_height="@dimen/notification_importance_toggle_size"
+            android:layout_centerVertical="true"
+            android:background="@drawable/ripple_drawable"
+            android:contentDescription="@string/notification_app_settings"
+            android:src="@drawable/ic_force_stop"
+            android:layout_toStartOf="@id/app_settings"
+            android:tint="@color/notification_guts_link_icon_tint"/>
+
         <ImageButton
             android:id="@+id/app_settings"
             android:layout_width="@dimen/notification_importance_toggle_size"

--- a/packages/SystemUI/res/values/afterlife_strings.xml
+++ b/packages/SystemUI/res/values/afterlife_strings.xml
@@ -159,4 +159,8 @@
     <!-- Navigation bar dpad -->
     <string name="accessibility_dpad_left">Cursor left</string>
     <string name="accessibility_dpad_right">Cursor right</string>
+
+    <!-- Kill button in notification guts -->
+    <string name="force_stop_dlg_title">Force stop?</string>
+    <string name="force_stop_dlg_text">If you force stop an app, it may misbehave.</string>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/qs/QSPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSPanel.java
@@ -18,9 +18,7 @@ package com.android.systemui.qs;
 
 import static com.android.systemui.util.Utils.useQsMediaPlayer;
 
-import android.animation.Animator;
-import android.animation.Animator.AnimatorListener;
-import android.animation.AnimatorListenerAdapter;
+
 import android.animation.ObjectAnimator;
 import android.annotation.NonNull;
 import android.annotation.Nullable;
@@ -29,10 +27,8 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Rect;
 import android.os.Bundle;
-import android.os.UserHandle;
 import android.os.Handler;
 import android.os.Message;
-import android.os.UserHandle;
 import android.provider.Settings;
 import android.util.ArrayMap;
 import android.util.AttributeSet;
@@ -77,6 +73,12 @@ public class QSPanel extends LinearLayout implements Tunable {
             Settings.Secure.QS_SHOW_BRIGHTNESS_SLIDER;
     public static final String QS_BRIGHTNESS_SLIDER_POSITION =
             Settings.Secure.QS_BRIGHTNESS_SLIDER_POSITION;
+    public static final String QS_TILE_ANIMATION_STYLE =
+            "system:" + Settings.System.QS_TILE_ANIMATION_STYLE;
+    public static final String QS_TILE_ANIMATION_DURATION =
+            "system:" + Settings.System.QS_TILE_ANIMATION_DURATION;
+    public static final String QS_TILE_ANIMATION_INTERPOLATOR =
+            "system:" + Settings.System.QS_TILE_ANIMATION_INTERPOLATOR;
 
     private static final String TAG = "QSPanel";
 
@@ -139,6 +141,10 @@ public class QSPanel extends LinearLayout implements Tunable {
      * false. It influences available accessibility actions.
      */
     private boolean mCanCollapse = true;
+
+    protected int mAnimStyle;
+    protected int mAnimDuration;
+    protected int mInterpolatorType;
 
     public QSPanel(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -383,6 +389,18 @@ public class QSPanel extends LinearLayout implements Tunable {
                     mAutoBrightnessView.setVisibility(mIsAutomaticBrightnessAvailable &&
                             TunerService.parseIntegerSwitch(newValue, true) ? View.VISIBLE : View.GONE);
                 }
+                break;
+            case QS_TILE_ANIMATION_STYLE:
+                mAnimStyle =
+                       TunerService.parseInteger(newValue, 0);
+                break;
+            case QS_TILE_ANIMATION_DURATION:
+                mAnimDuration =
+                       TunerService.parseInteger(newValue, 1);
+                break;
+            case QS_TILE_ANIMATION_INTERPOLATOR:
+                mInterpolatorType =
+                       TunerService.parseInteger(newValue, 0);
                 break;
             default:
                 break;
@@ -836,53 +854,48 @@ public class QSPanel extends LinearLayout implements Tunable {
 
     private void setAnimationTile(QSTileView v) {
         ObjectAnimator animTile = null;
-        int animStyle = Settings.System.getIntForUser(mContext.getContentResolver(),
-                Settings.System.ANIM_TILE_STYLE, 0, UserHandle.USER_CURRENT);
-        int animDuration = Settings.System.getIntForUser(mContext.getContentResolver(),
-                Settings.System.ANIM_TILE_DURATION, 2000, UserHandle.USER_CURRENT);
-        int interpolatorType = Settings.System.getIntForUser(mContext.getContentResolver(),
-                Settings.System.ANIM_TILE_INTERPOLATOR, 0, UserHandle.USER_CURRENT);
-        if (animStyle == 0) {
-            //No animation
+        switch (mAnimStyle) {
+            case 1:
+                animTile = ObjectAnimator.ofFloat(v, "rotationY", 0f, 360f);
+                break;
+            case 2:
+                animTile = ObjectAnimator.ofFloat(v, "rotation", 0f, 360f);
+                break;
+            default:
+                return;
         }
-        if (animStyle == 1) {
-            animTile = ObjectAnimator.ofFloat(v, "rotationY", 0f, 360f);
+
+        switch (mInterpolatorType) {
+            case 0:
+                animTile.setInterpolator(new LinearInterpolator());
+                break;
+            case 1:
+                animTile.setInterpolator(new AccelerateInterpolator());
+                break;
+            case 2:
+                animTile.setInterpolator(new DecelerateInterpolator());
+                break;
+            case 3:
+                animTile.setInterpolator(new AccelerateDecelerateInterpolator());
+                break;
+            case 4:
+                animTile.setInterpolator(new BounceInterpolator());
+                break;
+            case 5:
+                animTile.setInterpolator(new OvershootInterpolator());
+                break;
+            case 6:
+                animTile.setInterpolator(new AnticipateInterpolator());
+                break;
+            case 7:
+                animTile.setInterpolator(new AnticipateOvershootInterpolator());
+                break;
+            default:
+                break;
         }
-        if (animStyle == 2) {
-            animTile = ObjectAnimator.ofFloat(v, "rotation", 0f, 360f);
-        }
-        if (animTile != null) {
-            switch (interpolatorType) {
-                    case 0:
-                        animTile.setInterpolator(new LinearInterpolator());
-                        break;
-                    case 1:
-                        animTile.setInterpolator(new AccelerateInterpolator());
-                        break;
-                    case 2:
-                        animTile.setInterpolator(new DecelerateInterpolator());
-                        break;
-                    case 3:
-                        animTile.setInterpolator(new AccelerateDecelerateInterpolator());
-                        break;
-                    case 4:
-                        animTile.setInterpolator(new BounceInterpolator());
-                        break;
-                    case 5:
-                        animTile.setInterpolator(new OvershootInterpolator());
-                        break;
-                    case 6:
-                        animTile.setInterpolator(new AnticipateInterpolator());
-                        break;
-                    case 7:
-                        animTile.setInterpolator(new AnticipateOvershootInterpolator());
-                        break;
-                    default:
-                        break;
-            }
-            animTile.setDuration(animDuration);
-            animTile.start();
-        }
+
+        animTile.setDuration(mAnimDuration * 1000);
+        animTile.start();
     }
 
     private void tileClickListener(QSTile t, QSTileView v) {

--- a/packages/SystemUI/src/com/android/systemui/qs/QSPanelController.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSPanelController.java
@@ -114,6 +114,9 @@ public class QSPanelController extends QSPanelControllerBase<QSPanel> {
         mTunerService.addTunable(mView, QSPanel.QS_SHOW_BRIGHTNESS_SLIDER);
         mTunerService.addTunable(mView, QSPanel.QS_SHOW_AUTO_BRIGHTNESS);
         mTunerService.addTunable(mView, QSPanel.QS_BRIGHTNESS_SLIDER_POSITION);
+        mTunerService.addTunable(mView, QSPanel.QS_TILE_ANIMATION_STYLE);
+        mTunerService.addTunable(mView, QSPanel.QS_TILE_ANIMATION_DURATION);
+        mTunerService.addTunable(mView, QSPanel.QS_TILE_ANIMATION_INTERPOLATOR);
 
         mView.setBrightnessRunnable(() -> {
             mView.updateResources();

--- a/packages/SystemUI/src/com/android/systemui/qs/QuickQSPanelController.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QuickQSPanelController.java
@@ -115,6 +115,9 @@ public class QuickQSPanelController extends QSPanelControllerBase<QuickQSPanel> 
         mTunerService.addTunable(mView, QSPanel.QS_BRIGHTNESS_SLIDER_POSITION);
         mTunerService.addTunable(mView, QSPanel.QS_SHOW_AUTO_BRIGHTNESS);
         mTunerService.addTunable(mView, QSPanel.QS_SHOW_BRIGHTNESS_SLIDER);
+        mTunerService.addTunable(mView, QSPanel.QS_TILE_ANIMATION_STYLE);
+        mTunerService.addTunable(mView, QSPanel.QS_TILE_ANIMATION_DURATION);
+        mTunerService.addTunable(mView, QSPanel.QS_TILE_ANIMATION_INTERPOLATOR);
 
         mView.setBrightnessRunnable(() -> {
             mView.updateResources();

--- a/packages/SystemUI/src/com/android/systemui/statusbar/notification/row/NotificationInfo.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/notification/row/NotificationInfo.java
@@ -26,14 +26,18 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import android.annotation.IntDef;
 import android.annotation.Nullable;
+import android.app.ActivityManager;
 import android.app.INotificationManager;
+import android.app.KeyguardManager;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationChannelGroup;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.drawable.Drawable;
@@ -41,6 +45,8 @@ import android.metrics.LogMaker;
 import android.os.Handler;
 import android.os.RemoteException;
 import android.service.notification.StatusBarNotification;
+import android.os.UserHandle;
+import android.provider.Settings;
 import android.text.Html;
 import android.text.TextUtils;
 import android.transition.ChangeBounds;
@@ -61,6 +67,8 @@ import com.android.internal.logging.UiEventLogger;
 import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
 import com.android.systemui.Dependency;
 import com.android.systemui.R;
+import com.android.systemui.statusbar.phone.CentralSurfaces;
+import com.android.systemui.statusbar.phone.SystemUIDialog;
 import com.android.systemui.statusbar.notification.AssistantFeedbackController;
 import com.android.systemui.statusbar.notification.collection.NotificationEntry;
 
@@ -355,6 +363,43 @@ public class NotificationInfo extends LinearLayout implements NotificationGuts.G
         final View settingsButton = findViewById(R.id.info);
         settingsButton.setOnClickListener(getSettingsOnClickListener());
         settingsButton.setVisibility(settingsButton.hasOnClickListeners() ? VISIBLE : GONE);
+
+        // Force stop button
+        final View killButton = findViewById(R.id.force_stop);
+        boolean killButtonEnabled = Settings.System.getIntForUser(
+                mContext.getContentResolver(),
+                Settings.System.NOTIFICATION_GUTS_KILL_APP_BUTTON, 0,
+                UserHandle.USER_CURRENT) != 0;
+        if (killButtonEnabled && !isSystemPackage(mPackageName)) {
+            killButton.setVisibility(View.VISIBLE);
+            killButton.setOnClickListener(new View.OnClickListener() {
+                public void onClick(View v) {
+                    KeyguardManager keyguardManager = (KeyguardManager)
+                            mContext.getSystemService(Context.KEYGUARD_SERVICE);
+                    if (keyguardManager.inKeyguardRestrictedInputMode()) {
+                        // Don't do anything
+                        return;
+                    }
+                    final SystemUIDialog killDialog = new SystemUIDialog(mContext);
+                    killDialog.setTitle(mContext.getText(R.string.force_stop_dlg_title));
+                    killDialog.setMessage(mContext.getText(R.string.force_stop_dlg_text));
+                    killDialog.setPositiveButton(
+                            android.R.string.ok, new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            // kill pkg
+                            ActivityManager actMan =
+                                    (ActivityManager) mContext.getSystemService(
+                                    Context.ACTIVITY_SERVICE);
+                            actMan.forceStopPackage(mPackageName);
+                        }
+                    });
+                    killDialog.setNegativeButton(android.R.string.cancel, null);
+                    killDialog.show();
+                }
+            });
+        } else {
+            killButton.setVisibility(View.GONE);
+        }
     }
 
     private OnClickListener getSettingsOnClickListener() {
@@ -428,6 +473,21 @@ public class NotificationInfo extends LinearLayout implements NotificationGuts.G
             groupNameView.setVisibility(VISIBLE);
         } else {
             groupNameView.setVisibility(GONE);
+        }
+    }
+
+    private boolean isSystemPackage(String packageName) {
+        try {
+            final UserHandle userHandle = mSbn.getUser();
+            PackageManager pm = CentralSurfaces.getPackageManagerForUser(mContext,
+                    userHandle.getIdentifier());
+            PackageInfo packageInfo = pm.getPackageInfo(packageName,
+                    PackageManager.GET_SIGNATURES);
+            PackageInfo sys = pm.getPackageInfo("android", PackageManager.GET_SIGNATURES);
+            return (packageInfo != null && packageInfo.signatures != null &&
+                    sys.signatures[0].equals(packageInfo.signatures[0]));
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
         }
     }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/ScrimController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/ScrimController.java
@@ -26,8 +26,10 @@ import android.animation.ValueAnimator;
 import android.annotation.IntDef;
 import android.app.AlarmManager;
 import android.graphics.Color;
+import android.provider.Settings;
 import android.os.Handler;
 import android.os.Trace;
+import android.os.UserHandle;
 import android.util.Log;
 import android.util.MathUtils;
 import android.util.Pair;
@@ -179,6 +181,8 @@ public class ScrimController implements ViewTreeObserver.OnPreDrawListener, Dump
      * This should not be lower than 0.54, otherwise we won't pass GAR.
      */
     public static final float BUSY_SCRIM_ALPHA = 1f;
+
+    public static float mCustomScrimAlpha = 1f;
 
     /**
      * Scrim opacity that can have text on top.
@@ -367,6 +371,13 @@ public class ScrimController implements ViewTreeObserver.OnPreDrawListener, Dump
         if (mScrimBehindChangeRunnable != null) {
             mScrimBehind.setChangeRunnable(mScrimBehindChangeRunnable, mMainExecutor);
             mScrimBehindChangeRunnable = null;
+        }
+
+        if (mScrimBehind != null) {
+            mCustomScrimAlpha = (Settings.System.getFloatForUser(
+                mScrimBehind.getContext().getContentResolver(),
+                Settings.System.QS_TRANSPARENCY, 100,
+                UserHandle.USER_CURRENT) / 100);
         }
 
         final ScrimState[] states = ScrimState.values();
@@ -861,8 +872,8 @@ public class ScrimController implements ViewTreeObserver.OnPreDrawListener, Dump
                 } else if (mClipsQsScrim) {
                     float behindFraction = getInterpolatedFraction();
                     behindFraction = (float) Math.pow(behindFraction, 0.8f);
-                    mBehindAlpha = 1;
-                    mNotificationsAlpha = behindFraction * mDefaultScrimAlpha;
+                    mBehindAlpha = mCustomScrimAlpha;
+                    mNotificationsAlpha = behindFraction * mCustomScrimAlpha;
                 } else {
                     if (mFeatureFlags.isEnabled(Flags.LARGE_SHADE_GRANULAR_ALPHA_INTERPOLATION)) {
                         mBehindAlpha = mLargeScreenShadeInterpolator.getBehindScrimAlpha(
@@ -917,7 +928,7 @@ public class ScrimController implements ViewTreeObserver.OnPreDrawListener, Dump
             if (mClipsQsScrim) {
                 mNotificationsAlpha = behindAlpha;
                 mNotificationsTint = behindTint;
-                mBehindAlpha = 1;
+                mBehindAlpha = mCustomScrimAlpha;
                 mBehindTint = Color.TRANSPARENT;
             } else {
                 mBehindAlpha = behindAlpha;
@@ -969,7 +980,7 @@ public class ScrimController implements ViewTreeObserver.OnPreDrawListener, Dump
         float behindAlpha;
         int behindTint = state.getBehindTint();
         if (mDarkenWhileDragging) {
-            behindAlpha = MathUtils.lerp(mDefaultScrimAlpha, stateBehind,
+            behindAlpha = MathUtils.lerp(mCustomScrimAlpha, stateBehind,
                     interpolatedFract);
         } else {
             behindAlpha = MathUtils.lerp(0 /* start */, stateBehind,
@@ -985,7 +996,7 @@ public class ScrimController implements ViewTreeObserver.OnPreDrawListener, Dump
             }
         }
         if (mQsExpansion > 0) {
-            behindAlpha = MathUtils.lerp(behindAlpha, mDefaultScrimAlpha, mQsExpansion);
+            behindAlpha = MathUtils.lerp(behindAlpha, mCustomScrimAlpha, mQsExpansion);
             float tintProgress = mQsExpansion;
             if (mStatusBarKeyguardViewManager.isPrimaryBouncerInTransit()) {
                 // this is case of - on lockscreen - going from expanded QS to bouncer.

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/BatteryControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/BatteryControllerImpl.java
@@ -23,14 +23,20 @@ import static android.os.BatteryManager.EXTRA_PRESENT;
 
 import android.annotation.WorkerThread;
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.media.Ringtone;
+import android.media.RingtoneManager;
+import android.net.Uri;
 import android.os.BatteryManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.PowerManager;
 import android.os.PowerSaveState;
+import android.os.UserHandle;
+import android.provider.Settings;
 import android.util.Log;
 import android.view.View;
 
@@ -101,6 +107,7 @@ public class BatteryControllerImpl extends BroadcastReceiver implements BatteryC
     private final Object mEstimateLock = new Object();
 
     private boolean mFetchingEstimate = false;
+    private int mLastLevel = 0;
 
     // Use AtomicReference because we may request it from a different thread
     // Use WeakReference because we are keeping a reference to a View that's not as long lived
@@ -241,6 +248,9 @@ public class BatteryControllerImpl extends BroadcastReceiver implements BatteryC
             }
 
             fireBatteryLevelChanged();
+            if (mCharging) {
+                notificationBatteryChargeLevel();
+            }
         } else if (action.equals(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)) {
             updatePowerSave();
         } else if (action.equals(ACTION_LEVEL_TEST)) {
@@ -432,6 +442,27 @@ public class BatteryControllerImpl extends BroadcastReceiver implements BatteryC
                 mChangeCallbacks.get(i).onIsOverheatedChanged(mIsOverheated);
             }
         }
+    }
+
+    private void notificationBatteryChargeLevel() {
+        boolean enabled = Settings.System.getIntForUser(mContext.getContentResolver(),
+                            Settings.System.BATTERY_LEVEL_CHARGE_ALARM_ENABLED, 0,
+                            UserHandle.USER_CURRENT) == 1;
+        if (!enabled) return;
+        int level = Settings.System.getIntForUser(mContext.getContentResolver(),
+                        Settings.System.SEEK_BAR_BATTERY_CHARGE_LEVEL_SOUND, 100,
+                        UserHandle.USER_CURRENT);
+        if (level == mLevel && mLevel != mLastLevel) {
+            String alarmSound = Settings.Global.getString(mContext.getContentResolver(),
+                                    Settings.Global.BATTERY_LEVEL_CHARGE_SOUND_ALARM);
+            if (alarmSound != null && !alarmSound.equals("silent")) {
+                Ringtone batteryChargeLevelAlarm = RingtoneManager.getRingtone(mContext, Uri.parse(alarmSound));
+                if (batteryChargeLevelAlarm != null) {
+                    batteryChargeLevelAlarm.play();
+                }
+            }
+        }
+        mLastLevel = mLevel;
     }
 
     @Override


### PR DESCRIPTION
@neobuddy89:
* Updated for A13
* Use direct strings wherever possible
* Add FORCE_CLOSE priv-app permission
* Remove unused strings

SDB:Pie Bringup

[SpiritCroc]
- Make it a setting
- Don't allow killing apps when device is locked
- Bring it to Oreo

SagarMakhar: Convert TextView to ImageButton

Change-Id: Id2c2f3259ae2ff45ab28288375bc14148a0e9f1e