### PR TITLE
camera2: Add methods for backward compatibility

### DIFF
--- a/core/java/android/hardware/camera2/impl/CameraMetadataNative.java
+++ b/core/java/android/hardware/camera2/impl/CameraMetadataNative.java
@@ -2256,6 +2256,18 @@ public class CameraMetadataNative implements Parcelable {
     private static native int nativeGetTypeFromTag(int tag, long vendorId)
             throws IllegalArgumentException;
 
+    private synchronized byte[] nativeReadValues(int tag) {
+        return nativeReadValues(tag, mMetadataPtr);
+    }
+
+    private synchronized int nativeGetTypeFromTagLocal(int tag) {
+        return nativeGetTypeFromTagLocal(mMetadataPtr, tag);
+    }
+
+    private synchronized int nativeGetTagFromKeyLocal(String keyname) {
+        return nativeGetTagFromKeyLocal(mMetadataPtr, keyname);
+    }
+
     /**
      * <p>Perform a 0-copy swap of the internal metadata with another object.</p>
      *


### PR DESCRIPTION
libmcf-jni.so library (which is proprietary blob required for MotCamera2) looks for methods with these exact signatures, but signatures of these methods was changed in Android 11.

This change returns these methods that makes MotCamera2 fully-functional on Android 11.

Change-Id: Ib9a701f6d8ebb783c52666e34e7539faba5cb99f